### PR TITLE
docs: add architecture and design roadmap

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,58 @@
+# QuantBoard Architecture
+
+```mermaid
+graph TD
+    UI[streamlit_app] --> D[data]
+    UI --> I[indicators]
+    UI --> S[strategies]
+    UI --> B[backtest]
+    UI --> P[plots]
+    UI --> O[optimize]
+    B --> U[utils]
+```
+
+## Modules
+- **data.py**: descarga precios de `yfinance` con caching opcional y retorna `DataFrame` limpio.
+- **indicators.py**: implementa indicadores técnicos (SMA, EMA, RSI, MACD, Bollinger).
+- **strategies.py**: genera señales de trading a partir de indicadores (SMA crossover, RSI thresholds, Bollinger mean reversion, Donchian breakout).
+- **backtest.py**: ejecuta backtests simples y calcula métricas (CAGR, Sharpe, Max Drawdown).
+- **plots.py**: crea gráficos Plotly (OHLC con overlays, heatmaps).
+- **optimize.py**: búsqueda de parámetros (grid search) para SMA.
+- **utils.py**: utilidades matemáticas como `compute_cagr`, `compute_sharpe`, `max_drawdown` y constantes de calendario.
+- **streamlit_app.py**: interfaz de usuario que coordina la descarga de datos, generación de indicadores y señales, ejecución de backtest y gráficos.
+
+## Proposed final folder tree
+```text
+quantboard/
+├── app/
+│   └── streamlit_app.py
+├── data/
+│   ├── __init__.py
+│   └── price.py
+├── indicators/
+│   ├── __init__.py
+│   ├── moving_average.py
+│   ├── momentum.py
+│   └── volatility.py
+├── strategies/
+│   ├── __init__.py
+│   ├── trend.py
+│   ├── mean_reversion.py
+│   └── breakout.py
+├── backtest/
+│   ├── __init__.py
+│   ├── core.py
+│   └── metrics.py
+├── optimize/
+│   ├── __init__.py
+│   └── grid.py
+├── plots/
+│   ├── __init__.py
+│   ├── price.py
+│   └── heatmap.py
+├── utils/
+│   ├── __init__.py
+│   └── math.py
+└── tests/
+    └── test_example.py
+```

--- a/DESIGN_PRINCIPLES.md
+++ b/DESIGN_PRINCIPLES.md
@@ -1,0 +1,21 @@
+# Design Principles
+
+## Naming
+- Usar `snake_case` para funciones y variables; `PascalCase` para clases.
+- Nombres descriptivos, evitar abreviaturas salvo siglas comunes (SMA, RSI, etc.).
+
+## Typing
+- Emplear *type hints* y `typing` para parámetros y retornos.
+- Preferir `dataclass` o `pydantic` para estructuras de datos complejas.
+
+## Data validation
+- Validar entradas públicas (`ticker`, rangos, ventanas) y lanzar excepciones claras.
+- Normalizar `DataFrame`/`Series` antes de procesar (índices, tipos numéricos).
+
+## Error handling
+- Capturar excepciones externas (API, red) y traducirlas a errores propios del dominio.
+- Evitar silencios: registrar el error y devolver resultados vacíos solo si se justifica.
+
+## Logging
+- Usar el módulo estándar `logging` con niveles (`debug`, `info`, `warning`, `error`).
+- Configurar un logger jerárquico (`quantboard.*`) y permitir ajuste de nivel desde la app.

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,16 @@
+# Refactor Plan
+
+## Etapa 1 – Bajo riesgo
+- Añadir *docstrings* y *type hints* consistentes en todos los módulos.
+- Reemplazar `print`/`st.write` de depuración por `logging` y configurar nivel global.
+- Cubrir utilidades (`utils`, `indicators`) con tests unitarios básicos.
+
+## Etapa 2 – Riesgo medio
+- Dividir cada módulo en subpaquetes como en el árbol propuesto (`data/`, `strategies/`, etc.).
+- Centralizar la validación de parámetros usando `pydantic` o funciones dedicadas.
+- Crear una API de backtest orientada a objetos para soportar múltiples estrategias.
+
+## Etapa 3 – Alto impacto
+- Integrar múltiples fuentes de datos (ej. Alpaca, CSV local) con interfaz común y caching.
+- Implementar sistema de *plugins* para agregar estrategias e indicadores externos.
+- Añadir motor de backtesting con soporte de carteras y manejo de riesgo.


### PR DESCRIPTION
## Summary
- document current module interactions
- outline staged refactor plan and design principles

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf257ef58483278696f28f5f69f5f4