### PR TITLE
Add real-time 1-minute refresh option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Dashboard interactivo hecho con **Streamlit + yfinance + Plotly** para analizar 
 ---
 
 ## ¿Qué puedo hacer con QuantBoard?
-- Ver el **gráfico de precio** (OHLC) con overlays de SMA/EMA/Bollinger y panel de **RSI**.
+- Ver el **gráfico de precio** (OHLC) con overlays de SMA/EMA/Bollinger y panel de **RSI**. Ahora también soporta datos intradiarios de 1 minuto con auto-refresco opcional.
 - Generar **señales** con estrategias simples listas para usar.
 - Correr un **backtest** rápido y ver métricas clave (CAGR, Sharpe, MaxDD).
 - Explorar parámetros de SMA con un **heatmap** (grid search).

--- a/quantboard/data.py
+++ b/quantboard/data.py
@@ -2,7 +2,7 @@ import pandas as pd
 import yfinance as yf
 try:
     import streamlit as st
-    cache = st.cache_data(show_spinner=False, ttl=60*10)
+    cache = st.cache_data(show_spinner=False, ttl=60)
 except Exception:
     # fallback no-cache when not running in Streamlit
     def _no_cache(func):

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -2,6 +2,7 @@ import streamlit as st
 import pandas as pd
 from datetime import date, timedelta
 from plotly import graph_objs as go
+import time
 
 # QuantBoard package
 from quantboard.data import get_prices
@@ -24,7 +25,8 @@ st.sidebar.header("Configuración")
 ticker = st.sidebar.text_input("Ticker", value="AAPL")
 end = st.sidebar.date_input("Hasta", value=date.today())
 start = st.sidebar.date_input("Desde", value=date.today() - timedelta(days=365))
-interval = st.sidebar.selectbox("Intervalo", options=["1d", "1wk", "1mo"], index=0)
+interval = st.sidebar.selectbox("Intervalo", options=["1m", "1d", "1wk", "1mo"], index=1)
+auto_refresh = st.sidebar.checkbox("Auto-refrescar 1m", value=False)
 
 st.sidebar.markdown("---")
 st.sidebar.subheader("Indicadores")
@@ -63,7 +65,7 @@ st.title("QuantBoard — Análisis técnico y Backtesting")
 st.info("Configurá a la izquierda y apretá **Ejecutar** para empezar.")
 
 # --- Main run ---
-if run_btn:
+if run_btn or auto_refresh:
     with st.spinner("Descargando datos..."):
         df = get_prices(ticker, start=start, end=end, interval=interval)
         df = df.dropna()
@@ -111,6 +113,10 @@ if run_btn:
     eq_fig = go.Figure(go.Scatter(x=bt.index, y=bt["equity"], mode="lines", name="Equity"))
     eq_fig.update_layout(title="Curva de equity")
     st.plotly_chart(eq_fig, use_container_width=True)
+
+    if auto_refresh and interval == "1m":
+        time.sleep(60)
+        st.experimental_rerun()
 
 # --- Optimization grid ---
 if opt_btn:


### PR DESCRIPTION
## Summary
- Support intraday 1-minute data and optional auto-refresh in Streamlit app
- Reduce data cache TTL to 60 seconds for fresher quotes
- Document real-time capability in README

## Testing
- `pytest`
- `python -m py_compile streamlit_app.py quantboard/data.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf24fb8988832788a1dbd88d86f518