### PR TITLE
Refresh SMA heatmap and backtest pages with canonical content

### DIFF
--- a/pages/02_SMA_Heatmap.py
+++ b/pages/02_SMA_Heatmap.py
@@ -1,3 +1,6 @@
+"""SMA heatmap optimisation page."""
+from __future__ import annotations
+
 from datetime import date, timedelta
 
 import pandas as pd
@@ -13,14 +16,22 @@ apply_global_theme()
 
 
 def _validate_prices(df: pd.DataFrame) -> pd.Series | None:
+    """Return a cleaned *close* series or ``None`` when empty."""
     if df.empty or "close" not in df.columns:
         st.error("No data for the selected range/interval.")
         return None
+
     close = pd.to_numeric(df["close"], errors="coerce").dropna()
     if close.empty:
         st.error("No data for the selected range/interval.")
         return None
+
     return close
+
+
+@st.cache_data(ttl=60)
+def _load_prices(ticker: str, start: date, end: date) -> pd.DataFrame:
+    return get_prices(ticker, start=start, end=end, interval="1d")
 
 
 def main() -> None:
@@ -28,23 +39,24 @@ def main() -> None:
 
     with st.sidebar:
         st.header("Parameters")
-        ticker = st.text_input("Ticker", value="AAPL").strip().upper()
-        end = st.date_input("To", value=date.today())
-        start = st.date_input("From", value=date.today() - timedelta(days=365 * 2))
-        fast_min, fast_max = st.slider("Fast SMA range", 5, 60, (10, 25))
-        slow_min, slow_max = st.slider("Slow SMA range", 20, 240, (50, 120))
-        run_btn = st.button("Run search", type="primary")
+        with st.form("heatmap_form"):
+            ticker = st.text_input("Ticker", value="AAPL").strip().upper()
+            end = st.date_input("To", value=date.today())
+            start = st.date_input("From", value=date.today() - timedelta(days=365 * 2))
+            fast_min, fast_max = st.slider("Fast SMA range", 5, 60, (10, 25))
+            slow_min, slow_max = st.slider("Slow SMA range", 20, 240, (50, 120))
+            submitted = st.form_submit_button("Run search", type="primary")
+
+    if not submitted:
+        st.info("Choose parameters and click **Run search**.")
+        return
 
     if fast_min >= slow_min:
         st.error("Fast SMA range must stay below the Slow SMA range.")
         return
 
-    if not run_btn:
-        st.info("Choose parameters and click **Run search**.")
-        return
-
     with st.spinner("Fetching data..."):
-        df = get_prices(ticker, start=start, end=end, interval="1d")
+        df = _load_prices(ticker, start=start, end=end)
 
     close = _validate_prices(df)
     if close is None:
@@ -57,28 +69,30 @@ def main() -> None:
             slow_range=range(int(slow_min), int(slow_max) + 1),
             metric="Sharpe",
         )
-        # Invalidate combinations where fast >= slow
-        for f in z.index:
-            for s in z.columns:
-                if int(f) >= int(s):
-                    z.loc[f, s] = float("nan")
+
+    # Invalidate combinations where fast >= slow
+    for fast_window in z.index:
+        for slow_window in z.columns:
+            if int(fast_window) >= int(slow_window):
+                z.loc[fast_window, slow_window] = float("nan")
 
     st.subheader("Heatmap (Sharpe)")
     st.plotly_chart(heatmap_metric(z, title="SMA grid — Sharpe"), use_container_width=True)
 
-    # Best combination ignoring NaNs
-    best = z.stack().dropna().astype(float).idxmax() if z.stack().dropna().size else None
-    if best:
-        f_best, s_best = map(int, best)
-        st.success(f"Best combo: **Fast SMA {f_best} / Slow SMA {s_best}**")
-        if st.button("Use in Home"):
-            st.experimental_set_query_params(ticker=ticker)
-            try:
-                st.switch_page("streamlit_app.py")
-            except Exception:
-                st.info("Open Home from the menu; the ticker was set.")
-    else:
+    stacked = z.stack().dropna().astype(float)
+    if stacked.empty:
         st.warning("No valid combination found in the selected range.")
+        return
+
+    f_best, s_best = map(int, stacked.idxmax())
+    st.success(f"Best combo: **Fast SMA {f_best} / Slow SMA {s_best}**")
+
+    if st.button("Use in Home"):
+        st.experimental_set_query_params(ticker=ticker)
+        try:
+            st.switch_page("streamlit_app.py")
+        except Exception:  # pragma: no cover - depends on Streamlit runtime
+            st.info("Open Home from the menu; the ticker was set.")
 
 
 main()

--- a/pages/03_Backtest.py
+++ b/pages/03_Backtest.py
@@ -15,7 +15,7 @@ from quantboard.ui.theme import apply_global_theme
 
 try:
     from quantboard.strategies import signals_sma_crossover
-except Exception:  # pragma: no cover - fallback when optional module is missing
+except Exception:  # pragma: no cover - optional dependency guard
     signals_sma_crossover = None  # type: ignore[assignment]
 
 st.set_page_config(page_title="Backtest", page_icon="🧪", layout="wide")
@@ -29,24 +29,54 @@ def _validate_prices(df: pd.DataFrame) -> pd.DataFrame | None:
     return df
 
 
+def _clean_prices(df: pd.DataFrame) -> pd.DataFrame | None:
+    price_cols = ["open", "high", "low", "close", "volume"]
+    numeric = {col: pd.to_numeric(df.get(col), errors="coerce") for col in price_cols if col in df}
+    clean = df.assign(**numeric).dropna(subset=["close"])
+    if clean.empty:
+        st.error("No price data available after cleaning.")
+        return None
+    return clean
+
+
+def _run_signals(close: pd.Series, fast: int, slow: int) -> pd.Series:
+    if signals_sma_crossover is not None:
+        sig, _ = signals_sma_crossover(close, fast=fast, slow=slow)
+        return sig
+
+    sma_fast = sma(close, fast)
+    sma_slow = sma(close, slow)
+    cross_up = (sma_fast > sma_slow) & (sma_fast.shift(1) <= sma_slow.shift(1))
+    cross_dn = (sma_fast < sma_slow) & (sma_fast.shift(1) >= sma_slow.shift(1))
+    sig = pd.Series(0.0, index=close.index)
+    sig = sig.where(~cross_up, 1.0)
+    sig = sig.where(~cross_dn, -1.0)
+    return sig.replace(0, pd.NA).ffill().fillna(0.0)
+
+
 def main() -> None:
     st.title("Backtest — SMA crossover")
 
     with st.sidebar:
         st.header("Parameters")
-        ticker = st.text_input("Ticker", value="AAPL").strip().upper()
-        end = st.date_input("To", value=date.today())
-        start = st.date_input("From", value=date.today() - timedelta(days=365 * 2))
-        interval = st.selectbox("Interval", ["1d", "1h", "1wk", "1m"], index=0)
-        fast = st.number_input("Fast SMA", 5, 200, 20, step=1)
-        slow = st.number_input("Slow SMA", 10, 400, 50, step=1)
-        fee_bps = st.number_input("Fees (bps)", 0, 50, 0, step=1)
-        slip_bps = st.number_input("Slippage (bps)", 0, 50, 0, step=1)
-        run_btn = st.button("Run backtest", type="primary")
+        with st.form("backtest_form"):
+            ticker = st.text_input("Ticker", value="AAPL").strip().upper()
+            end = st.date_input("To", value=date.today())
+            start = st.date_input("From", value=date.today() - timedelta(days=365 * 2))
+            interval = st.selectbox("Interval", ["1d", "1h", "1wk", "1m"], index=0)
+            fast = st.number_input("Fast SMA", 5, 200, 20, step=1)
+            slow = st.number_input("Slow SMA", 10, 400, 50, step=1)
+            fee_bps = st.number_input("Fees (bps)", 0, 50, 0, step=1)
+            slip_bps = st.number_input("Slippage (bps)", 0, 50, 0, step=1)
+            submitted = st.form_submit_button("Run backtest", type="primary")
 
     st.info("Configure the sidebar parameters and run the backtest.")
 
-    if not run_btn:
+    if not submitted:
+        return
+
+    if fast >= slow:
+        st.error("Fast SMA must be smaller than Slow SMA.")
         return
 
     with st.spinner("Fetching data..."):
@@ -56,57 +86,41 @@ def main() -> None:
     if df is None:
         return
 
-    # Series limpias
-    close = pd.to_numeric(df["close"], errors="coerce")
-    df = df.assign(close=close).dropna(subset=["close"])
+    df = _clean_prices(df)
+    if df is None:
+        return
 
-    # Signals
-    if signals_sma_crossover is not None:
-        sig, _ = signals_sma_crossover(df["close"], fast=int(fast), slow=int(slow))
-    else:
-        # Local fallback if the shared strategies module is unavailable
-        sma_fast = sma(df["close"], int(fast))
-        sma_slow = sma(df["close"], int(slow))
-        cross_up = (sma_fast > sma_slow) & (sma_fast.shift(1) <= sma_slow.shift(1))
-        cross_dn = (sma_fast < sma_slow) & (sma_fast.shift(1) >= sma_slow.shift(1))
-        sig = pd.Series(0, index=df.index, dtype=float)
-        sig = sig.where(~cross_up, 1.0)
-        sig = sig.where(~cross_dn, -1.0)
-        sig = sig.replace(0, pd.NA).ffill().fillna(0.0)
+    signals = _run_signals(df["close"], fast=int(fast), slow=int(slow))
 
-    # Backtest
     bt, metrics = run_backtest(
         df,
-        signals=sig,
+        signals=signals,
         fee_bps=int(fee_bps),
         slippage_bps=int(slip_bps),
         interval=interval,
     )
 
-    # --------- Charts ---------
     st.subheader("Price and SMAs")
-
     sma_fast = sma(df["close"], int(fast))
     sma_slow = sma(df["close"], int(slow))
 
     price_fig = go.Figure()
     price_fig.add_candlestick(
         x=df.index,
-        open=pd.to_numeric(df.get("open", df["close"]), errors="coerce"),
-        high=pd.to_numeric(df.get("high", df["close"]), errors="coerce"),
-        low=pd.to_numeric(df.get("low", df["close"]), errors="coerce"),
+        open=df.get("open", df["close"]),
+        high=df.get("high", df["close"]),
+        low=df.get("low", df["close"]),
         close=df["close"],
-        name="OHLC",
+        name="ohlc",
     )
     price_fig.add_trace(
-        go.Scatter(x=sma_fast.index, y=sma_fast, mode="lines", name=f"SMA {fast}")
+        go.Scatter(x=sma_fast.index, y=sma_fast, mode="lines", name=f"SMA {int(fast)}"),
     )
     price_fig.add_trace(
-        go.Scatter(x=sma_slow.index, y=sma_slow, mode="lines", name=f"SMA {slow}")
+        go.Scatter(x=sma_slow.index, y=sma_slow, mode="lines", name=f"SMA {int(slow)}"),
     )
 
-    # Buy/Sell markers
-    changes = sig.diff().fillna(0)
+    changes = signals.diff().fillna(0)
     buys = df.index[changes > 0]
     sells = df.index[changes < 0]
     price_fig.add_trace(
@@ -117,7 +131,7 @@ def main() -> None:
             marker_symbol="triangle-up",
             marker_size=10,
             name="Buy",
-        )
+        ),
     )
     price_fig.add_trace(
         go.Scatter(
@@ -127,7 +141,7 @@ def main() -> None:
             marker_symbol="triangle-down",
             marker_size=10,
             name="Sell",
-        )
+        ),
     )
 
     price_fig.update_layout(margin=dict(l=30, r=20, t=30, b=30), height=520)
@@ -140,10 +154,9 @@ def main() -> None:
     apply_plotly_theme(eq_fig)
     st.plotly_chart(eq_fig, use_container_width=True)
 
-    # Metrics
     st.subheader("Metrics")
-    mdf = pd.DataFrame([metrics]).T.rename(columns={0: "Value"})
-    st.dataframe(mdf.style.format({"Value": "{:.4f}"}), use_container_width=True)
+    metrics_df = pd.DataFrame([metrics]).T.rename(columns={0: "Value"})
+    st.dataframe(metrics_df.style.format({"Value": "{:.4f}"}), use_container_width=True)
 
 
 main()

--- a/pages/06_RSI_Strategy.py
+++ b/pages/06_RSI_Strategy.py
@@ -1,0 +1,192 @@
+"""RSI strategy backtest page."""
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import pandas as pd
+import plotly.graph_objects as go
+import streamlit as st
+
+from quantboard.backtest import run_backtest
+from quantboard.data import get_prices
+from quantboard.indicators import rsi
+from quantboard.plots import apply_plotly_theme
+from quantboard.ui.theme import apply_global_theme
+
+st.set_page_config(page_title="RSI Strategy", page_icon="📈", layout="wide")
+apply_global_theme()
+
+
+def _validate_prices(df: pd.DataFrame) -> pd.DataFrame | None:
+    if df.empty or "close" not in df.columns:
+        st.error("No data for the selected range/interval.")
+        return None
+    return df
+
+
+def _clean_prices(df: pd.DataFrame) -> pd.DataFrame | None:
+    price_cols = ["open", "high", "low", "close", "volume"]
+    numeric = {col: pd.to_numeric(df.get(col), errors="coerce") for col in price_cols if col in df}
+    clean = df.assign(**numeric).dropna(subset=["close"])
+    if clean.empty:
+        st.error("No price data available after cleaning.")
+        return None
+    return clean
+
+
+def _price_with_signals(
+    df: pd.DataFrame,
+    signals: pd.Series,
+    overlays: dict[str, pd.Series | pd.DataFrame] | None = None,
+) -> go.Figure:
+    overlays = overlays or {}
+    fig = go.Figure()
+    fig.add_candlestick(
+        x=df.index,
+        open=df.get("open", df["close"]),
+        high=df.get("high", df["close"]),
+        low=df.get("low", df["close"]),
+        close=df["close"],
+        name="ohlc",
+    )
+
+    for name, series in overlays.items():
+        if isinstance(series, pd.DataFrame):
+            for sub_name, ser in series.items():
+                fig.add_trace(
+                    go.Scatter(x=ser.index, y=ser.values, mode="lines", name=f"{name} ({sub_name})"),
+                )
+        elif series is not None:
+            fig.add_trace(go.Scatter(x=series.index, y=series.values, mode="lines", name=name))
+
+    changes = signals.diff().fillna(signals.iloc[0] if len(signals) else 0.0)
+    buys = df.index[changes > 0]
+    sells = df.index[changes < 0]
+
+    if len(buys):
+        fig.add_trace(
+            go.Scatter(
+                x=buys,
+                y=df.loc[buys, "close"],
+                mode="markers",
+                marker_symbol="triangle-up",
+                marker_size=10,
+                name="Buy",
+            ),
+        )
+    if len(sells):
+        fig.add_trace(
+            go.Scatter(
+                x=sells,
+                y=df.loc[sells, "close"],
+                mode="markers",
+                marker_symbol="triangle-down",
+                marker_size=10,
+                name="Sell/Short",
+            ),
+        )
+
+    fig.update_layout(margin=dict(l=30, r=20, t=30, b=30), height=520)
+    return apply_plotly_theme(fig)
+
+
+def _build_signals(
+    close: pd.Series,
+    *,
+    period: int,
+    lower: float,
+    upper: float,
+    mode: str,
+) -> tuple[pd.Series, dict[str, pd.Series]]:
+    rsi_series = rsi(close, window=period)
+    go_long = (rsi_series.shift(1) < lower) & (rsi_series >= lower)
+    go_flat = (rsi_series.shift(1) > upper) & (rsi_series <= upper)
+
+    signals = pd.Series(index=close.index, dtype=float)
+    signals.loc[go_long] = 1.0
+
+    if mode == "Long only":
+        signals.loc[go_flat] = 0.0
+    else:
+        signals.loc[go_flat] = -1.0
+
+    signals = signals.ffill().fillna(0.0)
+
+    if mode == "Long only":
+        signals = signals.clip(lower=0.0, upper=1.0)
+    else:
+        signals = signals.clip(-1.0, 1.0)
+
+    return signals, {"RSI": rsi_series}
+
+
+def main() -> None:
+    st.title("Backtest — RSI strategy")
+
+    with st.sidebar:
+        st.header("Parameters")
+        with st.form("rsi_form"):
+            ticker = st.text_input("Ticker", value="AAPL").strip().upper()
+            end = st.date_input("To", value=date.today())
+            start = st.date_input("From", value=date.today() - timedelta(days=365 * 2))
+            interval = st.selectbox("Interval", ["1d", "1h", "1wk"], index=0)
+            period = st.number_input("RSI period", 2, 100, 14, step=1)
+            lower = st.number_input("Lower threshold", 0, 100, 30, step=1)
+            upper = st.number_input("Upper threshold", 0, 100, 70, step=1)
+            mode = st.selectbox("Signal mode", ["Long only", "Flip long/short"], index=0)
+            fee_bps = st.number_input("Fees (bps)", 0, 50, 0, step=1)
+            slip_bps = st.number_input("Slippage (bps)", 0, 50, 0, step=1)
+            submitted = st.form_submit_button("Run backtest", type="primary")
+
+    st.info("Configure the sidebar parameters and run the backtest.")
+
+    if not submitted:
+        return
+
+    if lower >= upper:
+        st.error("Lower threshold must be less than Upper threshold.")
+        return
+
+    with st.spinner("Fetching data..."):
+        df = get_prices(ticker, start=start, end=end, interval=interval)
+
+    df = _validate_prices(df)
+    if df is None:
+        return
+
+    df = _clean_prices(df)
+    if df is None:
+        return
+
+    signals, overlays = _build_signals(
+        df["close"],
+        period=int(period),
+        lower=float(lower),
+        upper=float(upper),
+        mode=mode,
+    )
+
+    bt, metrics = run_backtest(
+        df,
+        signals=signals,
+        fee_bps=int(fee_bps),
+        slippage_bps=int(slip_bps),
+        interval=interval,
+    )
+
+    st.subheader("Price and signals")
+    price_fig = _price_with_signals(df, signals, overlays)
+    st.plotly_chart(price_fig, use_container_width=True)
+
+    st.subheader("Equity curve")
+    eq_fig = go.Figure(go.Scatter(x=bt.index, y=bt["equity"], mode="lines", name="Equity"))
+    eq_fig.update_layout(margin=dict(l=30, r=20, t=30, b=30), height=320)
+    apply_plotly_theme(eq_fig)
+    st.plotly_chart(eq_fig, use_container_width=True)
+
+    st.subheader("Metrics")
+    metrics_df = pd.DataFrame([metrics]).T.rename(columns={0: "Value"})
+    st.dataframe(metrics_df.style.format({"Value": "{:.4f}"}), use_container_width=True)
+
+
+main()

--- a/pages/07_Bollinger_MR.py
+++ b/pages/07_Bollinger_MR.py
@@ -1,0 +1,154 @@
+"""Bollinger Bands mean-reversion strategy page."""
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import pandas as pd
+import plotly.graph_objects as go
+import streamlit as st
+
+from quantboard.backtest import run_backtest
+from quantboard.data import get_prices
+from quantboard.plots import apply_plotly_theme
+from quantboard.strategies import signals_bollinger_mean_reversion
+from quantboard.ui.theme import apply_global_theme
+
+st.set_page_config(page_title="Bollinger Mean Reversion", page_icon="📊", layout="wide")
+apply_global_theme()
+
+
+def _validate_prices(df: pd.DataFrame) -> pd.DataFrame | None:
+    if df.empty or "close" not in df.columns:
+        st.error("No data for the selected range/interval.")
+        return None
+    return df
+
+
+def _clean_prices(df: pd.DataFrame) -> pd.DataFrame | None:
+    price_cols = ["open", "high", "low", "close", "volume"]
+    numeric = {col: pd.to_numeric(df.get(col), errors="coerce") for col in price_cols if col in df}
+    clean = df.assign(**numeric).dropna(subset=["close"])
+    if clean.empty:
+        st.error("No price data available after cleaning.")
+        return None
+    return clean
+
+
+def _price_with_signals(
+    df: pd.DataFrame,
+    signals: pd.Series,
+    overlays: dict[str, pd.Series | pd.DataFrame] | None = None,
+) -> go.Figure:
+    overlays = overlays or {}
+    fig = go.Figure()
+    fig.add_candlestick(
+        x=df.index,
+        open=df.get("open", df["close"]),
+        high=df.get("high", df["close"]),
+        low=df.get("low", df["close"]),
+        close=df["close"],
+        name="ohlc",
+    )
+
+    for name, series in overlays.items():
+        if isinstance(series, pd.DataFrame):
+            for sub_name, ser in series.items():
+                fig.add_trace(
+                    go.Scatter(x=ser.index, y=ser.values, mode="lines", name=f"{name} ({sub_name})"),
+                )
+        elif series is not None:
+            fig.add_trace(go.Scatter(x=series.index, y=series.values, mode="lines", name=name))
+
+    changes = signals.diff().fillna(signals.iloc[0] if len(signals) else 0.0)
+    buys = df.index[changes > 0]
+    sells = df.index[changes < 0]
+
+    if len(buys):
+        fig.add_trace(
+            go.Scatter(
+                x=buys,
+                y=df.loc[buys, "close"],
+                mode="markers",
+                marker_symbol="triangle-up",
+                marker_size=10,
+                name="Buy",
+            ),
+        )
+    if len(sells):
+        fig.add_trace(
+            go.Scatter(
+                x=sells,
+                y=df.loc[sells, "close"],
+                mode="markers",
+                marker_symbol="triangle-down",
+                marker_size=10,
+                name="Sell",
+            ),
+        )
+
+    fig.update_layout(margin=dict(l=30, r=20, t=30, b=30), height=520)
+    return apply_plotly_theme(fig)
+
+
+def main() -> None:
+    st.title("Backtest — Bollinger mean reversion")
+
+    with st.sidebar:
+        st.header("Parameters")
+        with st.form("bb_form"):
+            ticker = st.text_input("Ticker", value="AAPL").strip().upper()
+            end = st.date_input("To", value=date.today())
+            start = st.date_input("From", value=date.today() - timedelta(days=365 * 2))
+            interval = st.selectbox("Interval", ["1d", "1h", "1wk"], index=0)
+            window = st.number_input("Window", 5, 200, 20, step=1)
+            n_std = st.number_input("Std dev", 1.0, 5.0, 2.0, step=0.5)
+            fee_bps = st.number_input("Fees (bps)", 0, 50, 0, step=1)
+            slip_bps = st.number_input("Slippage (bps)", 0, 50, 0, step=1)
+            submitted = st.form_submit_button("Run backtest", type="primary")
+
+    st.info("Configure the sidebar parameters and run the backtest.")
+
+    if not submitted:
+        return
+
+    with st.spinner("Fetching data..."):
+        df = get_prices(ticker, start=start, end=end, interval=interval)
+
+    df = _validate_prices(df)
+    if df is None:
+        return
+
+    df = _clean_prices(df)
+    if df is None:
+        return
+
+    signals, overlays = signals_bollinger_mean_reversion(
+        df["close"],
+        window=int(window),
+        n_std=float(n_std),
+    )
+
+    bt, metrics = run_backtest(
+        df,
+        signals=signals,
+        fee_bps=int(fee_bps),
+        slippage_bps=int(slip_bps),
+        interval=interval,
+    )
+
+    st.subheader("Price and bands")
+    price_fig = _price_with_signals(df, signals, overlays)
+    st.plotly_chart(price_fig, use_container_width=True)
+
+    st.subheader("Equity curve")
+    eq_fig = go.Figure(go.Scatter(x=bt.index, y=bt["equity"], mode="lines", name="Equity"))
+    eq_fig.update_layout(margin=dict(l=30, r=20, t=30, b=30), height=320)
+    apply_plotly_theme(eq_fig)
+    st.plotly_chart(eq_fig, use_container_width=True)
+
+    st.subheader("Metrics")
+    metrics_df = pd.DataFrame([metrics]).T.rename(columns={0: "Value"})
+    st.dataframe(metrics_df.style.format({"Value": "{:.4f}"}), use_container_width=True)
+
+
+main()

--- a/pages/08_Donchian_Breakout.py
+++ b/pages/08_Donchian_Breakout.py
@@ -1,0 +1,154 @@
+"""Donchian channel breakout strategy page."""
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import pandas as pd
+import plotly.graph_objects as go
+import streamlit as st
+
+from quantboard.backtest import run_backtest
+from quantboard.data import get_prices
+from quantboard.plots import apply_plotly_theme
+from quantboard.strategies import signals_donchian_breakout
+from quantboard.ui.theme import apply_global_theme
+
+st.set_page_config(page_title="Donchian Breakout", page_icon="📣", layout="wide")
+apply_global_theme()
+
+
+def _validate_prices(df: pd.DataFrame) -> pd.DataFrame | None:
+    if df.empty or "close" not in df.columns:
+        st.error("No data for the selected range/interval.")
+        return None
+    return df
+
+
+def _clean_prices(df: pd.DataFrame) -> pd.DataFrame | None:
+    price_cols = ["open", "high", "low", "close", "volume"]
+    numeric = {col: pd.to_numeric(df.get(col), errors="coerce") for col in price_cols if col in df}
+    clean = df.assign(**numeric).dropna(subset=["close"])
+    if clean.empty:
+        st.error("No price data available after cleaning.")
+        return None
+    return clean
+
+
+def _price_with_signals(
+    df: pd.DataFrame,
+    signals: pd.Series,
+    overlays: dict[str, pd.Series | pd.DataFrame] | None = None,
+) -> go.Figure:
+    overlays = overlays or {}
+    fig = go.Figure()
+    fig.add_candlestick(
+        x=df.index,
+        open=df.get("open", df["close"]),
+        high=df.get("high", df["close"]),
+        low=df.get("low", df["close"]),
+        close=df["close"],
+        name="ohlc",
+    )
+
+    for name, series in overlays.items():
+        if isinstance(series, pd.DataFrame):
+            for sub_name, ser in series.items():
+                fig.add_trace(
+                    go.Scatter(x=ser.index, y=ser.values, mode="lines", name=f"{name} ({sub_name})"),
+                )
+        elif series is not None:
+            fig.add_trace(go.Scatter(x=series.index, y=series.values, mode="lines", name=name))
+
+    changes = signals.diff().fillna(signals.iloc[0] if len(signals) else 0.0)
+    buys = df.index[changes > 0]
+    sells = df.index[changes < 0]
+
+    if len(buys):
+        fig.add_trace(
+            go.Scatter(
+                x=buys,
+                y=df.loc[buys, "close"],
+                mode="markers",
+                marker_symbol="triangle-up",
+                marker_size=10,
+                name="Breakout",
+            ),
+        )
+    if len(sells):
+        fig.add_trace(
+            go.Scatter(
+                x=sells,
+                y=df.loc[sells, "close"],
+                mode="markers",
+                marker_symbol="triangle-down",
+                marker_size=10,
+                name="Exit",
+            ),
+        )
+
+    fig.update_layout(margin=dict(l=30, r=20, t=30, b=30), height=520)
+    return apply_plotly_theme(fig)
+
+
+def main() -> None:
+    st.title("Backtest — Donchian breakout")
+
+    with st.sidebar:
+        st.header("Parameters")
+        with st.form("donchian_form"):
+            ticker = st.text_input("Ticker", value="AAPL").strip().upper()
+            end = st.date_input("To", value=date.today())
+            start = st.date_input("From", value=date.today() - timedelta(days=365 * 2))
+            interval = st.selectbox("Interval", ["1d", "1h", "1wk"], index=0)
+            window = st.number_input("Channel length", 5, 200, 20, step=1)
+            fee_bps = st.number_input("Fees (bps)", 0, 50, 0, step=1)
+            slip_bps = st.number_input("Slippage (bps)", 0, 50, 0, step=1)
+            submitted = st.form_submit_button("Run backtest", type="primary")
+
+    st.info("Configure the sidebar parameters and run the backtest.")
+
+    if not submitted:
+        return
+
+    with st.spinner("Fetching data..."):
+        df = get_prices(ticker, start=start, end=end, interval=interval)
+
+    df = _validate_prices(df)
+    if df is None:
+        return
+
+    df = _clean_prices(df)
+    if df is None:
+        return
+
+    signals, overlays = signals_donchian_breakout(
+        df.get("high", df["close"]),
+        df.get("low", df["close"]),
+        df["close"],
+        window=int(window),
+    )
+
+    bt, metrics = run_backtest(
+        df,
+        signals=signals,
+        fee_bps=int(fee_bps),
+        slippage_bps=int(slip_bps),
+        interval=interval,
+    )
+
+    st.subheader("Price and channels")
+    price_fig = _price_with_signals(df, signals, overlays)
+    st.plotly_chart(price_fig, use_container_width=True)
+
+    st.subheader("Equity curve")
+    eq_fig = go.Figure(go.Scatter(x=bt.index, y=bt["equity"], mode="lines", name="Equity"))
+    eq_fig.update_layout(margin=dict(l=30, r=20, t=30, b=30), height=320)
+    apply_plotly_theme(eq_fig)
+    st.plotly_chart(eq_fig, use_container_width=True)
+
+    st.subheader("Metrics")
+    metrics_df = pd.DataFrame([metrics]).T.rename(columns={0: "Value"})
+    st.dataframe(metrics_df.style.format({"Value": "{:.4f}"}), use_container_width=True)
+
+
+main()


### PR DESCRIPTION
## Summary
- replace the SMA Heatmap page with the canonical form-driven implementation that caches price data and validates ranges
- update the Backtest page to the canonical version with cleaned price handling, guardrails, and lower-case ohlc labelling
- add RSI, Bollinger mean reversion, and Donchian breakout strategy pages that reuse the shared backtest workflow

## Testing
- python -m py_compile streamlit_app.py
- python -m py_compile pages/02_SMA_Heatmap.py
- python -m py_compile pages/03_Backtest.py
- python -m py_compile pages/06_RSI_Strategy.py
- python -m py_compile pages/07_Bollinger_MR.py
- python -m py_compile pages/08_Donchian_Breakout.py

------
https://chatgpt.com/codex/tasks/task_e_68dd5088dabc8327a79259abec2ea6fc